### PR TITLE
Add Dependabot versioning scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    # location of package manifests
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     # default location of `.github/workflows`
     directory: "/"
+    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "nuget"
     # location of package manifests
     directory: "/"
+    open-pull-requests-limit: 10
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
- add `dependabot.yml` which serves as a configuration file for the Dependabot dependency versioning scan by listing what ecosystems it should look and scan for